### PR TITLE
Fix buit-in mode types Socks5 and Socks5 + HTTP

### DIFF
--- a/mode/Bypass LAN (Socks5 + HTTP) (Non System Proxy).txt
+++ b/mode/Bypass LAN (Socks5 + HTTP) (Non System Proxy).txt
@@ -1,1 +1,1 @@
-# Bypass LAN (Socks5 + HTTP) (Non System Proxy), 4, 0
+# Bypass LAN (Socks5 + HTTP) (Non System Proxy), 5, 0

--- a/mode/Bypass LAN (Socks5) (Non System Proxy).txt
+++ b/mode/Bypass LAN (Socks5) (Non System Proxy).txt
@@ -1,1 +1,1 @@
-# Bypass LAN (Socks5) (Non System Proxy), 5, 0
+# Bypass LAN (Socks5) (Non System Proxy), 4, 0

--- a/mode/Bypass LAN and China (Socks5 + HTTP) (Non System Proxy).txt
+++ b/mode/Bypass LAN and China (Socks5 + HTTP) (Non System Proxy).txt
@@ -1,1 +1,1 @@
-# Bypass LAN and China (Socks5 + HTTP) (Non System Proxy), 4, 1
+# Bypass LAN and China (Socks5 + HTTP) (Non System Proxy), 5, 1

--- a/mode/Bypass LAN and China (Socks5) (Non System Proxy).txt
+++ b/mode/Bypass LAN and China (Socks5) (Non System Proxy).txt
@@ -1,1 +1,1 @@
-# Bypass LAN and China (Socks5) (Non System Proxy), 5, 1
+# Bypass LAN and China (Socks5) (Non System Proxy), 4, 1


### PR DESCRIPTION
可修复非系统代理的HTTP代理无法连接的问题