### PR TITLE
Add ssh.exe for vscode remote plugin.

### DIFF
--- a/mode/Visual Studio Code.txt
+++ b/mode/Visual Studio Code.txt
@@ -5,3 +5,4 @@ inno_updater.exe
 CodeHelper.exe
 rg.exe
 winpty-agent.exe
+ssh.exe


### PR DESCRIPTION
Current version of vscode need this PR to make use of Netch proxy in remote plugin.