### PR TITLE
Add DLsite PlayDRM

### DIFF
--- a/mode/Game/DLsite PlayDRM.txt
+++ b/mode/Game/DLsite PlayDRM.txt
@@ -1,0 +1,2 @@
+# DLsite PlayDRM, 0
+startup.exe


### PR DESCRIPTION
DLsite PlayDRM is a serial key style protection software designed to prevent illegal redistribution and copyright infringement. ([What is PlayDRM?](https://www.dlsite.com/ecchi-eng/faq/detail/=/type/user/mid/7/did/510))

startup.exe - It is the entry for most games that use PlayDRM. ([如何使用Proxifier进行PlayDRM认证](https://blog.wsswms.dev/2020/03/27/how-to-fuck-the-PlayDRM/#B-2-%E8%AE%BE%E7%BD%AE%E4%BB%A3%E7%90%86%E8%A7%84%E5%88%99-Proxification-Rules))